### PR TITLE
Feat/make image distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,29 @@
-FROM rust:buster
+FROM rust:1.76.0 AS builder
+
 WORKDIR /usr/src/app
 COPY . .
 
-RUN cargo install diesel_cli --no-default-features --features sqlite # ORM
-RUN diesel setup # Migrations
 RUN cargo build --release
+
+# Find and copy the libsqlite3.so.0 library
+RUN find / -name libsqlite3.so.0 -exec cp {} /tmp/libsqlite3.so.0 \;
+
+
+FROM gcr.io/distroless/cc-debian12
+COPY --from=builder /usr/src/app/target/release/videas /usr/local/bin/videas
+# Copy the libsqlite3.so.0 library to the final image
+COPY --from=builder /tmp/libsqlite3.so.0 /usr/lib/
+
+WORKDIR /app
+# Copy required files to the final image
+COPY --from=builder /usr/src/app/static ./static
+COPY --from=builder /usr/src/app/templates ./templates
+COPY --from=builder /usr/src/app/db.sqlite3 ./db.sqlite3
+
+
+ENV DATABASE_URL="file:db.sqlite3"
+ENV RUST_LOG=debug
 
 EXPOSE 8080
 
-CMD ["cargo", "run", "--release"]
+CMD ["/usr/local/bin/videas"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
         - .:/usr/src/app
       env_file: .env
       environment:
-        - RUST_LOG=trace
+        - RUST_LOG=debug
       tty: true
       ports:
       - "8080:8080"

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,10 +1,12 @@
-use diesel::Connection;
 use diesel::sqlite::SqliteConnection;
+use diesel::Connection;
+use log::info;
 
-pub mod schema;
 pub mod models;
+pub mod schema;
 
 pub fn connect_db() -> SqliteConnection {
     let url = ::std::env::var("DATABASE_URL").expect("DATABASE_URL not set");
+    info!("Connecting to {}", &url);
     SqliteConnection::establish(&url).unwrap_or_else(|_| panic!("Couldn't connect to {}", url))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,14 @@
-use actix_web::{App, HttpServer, middleware::Logger};
 use actix_files as fs;
+use actix_web::{middleware::Logger, App, HttpServer};
 use dotenvy::dotenv;
 use videas::routes::*;
 
 #[actix_web::main]
 #[doc(hidden)]
 async fn main() -> std::io::Result<()> {
-    dotenv().expect(".env file not found");
+    // We need this to load the .env file  only in development.
+    // It's better to use other ways to load the environment variables in production.
+    dotenv().ok();
     env_logger::init();
 
     HttpServer::new(|| {
@@ -21,4 +23,3 @@ async fn main() -> std::io::Result<()> {
     .run()
     .await
 }
-

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,12 +1,11 @@
-use actix_web::{get, HttpResponse, Responder, web};
-use log::{info};
-use super::templates::*;
 use super::posts;
+use super::templates::*;
+use actix_web::{get, web, HttpResponse, Responder};
 use askama_actix::TemplateToResponse;
+use log::info;
 
 // Due sqlite limitations this is the defaul value of posts' slug
 const NO_SLUG: &str = "NO_SLUG";
-
 
 #[get("ping")]
 #[doc(hidden)]
@@ -18,6 +17,7 @@ pub async fn ping() -> impl Responder {
 #[doc(hidden)]
 pub async fn index() -> impl Responder {
     let posts_ = posts::all();
+    info!("Rendering index with {} posts", posts_.len());
     IndexTemplate { posts: &posts_ }.to_response()
 }
 
@@ -40,4 +40,3 @@ fn log_and_render_not_found(message: &str) -> HttpResponse {
     info!("{}; rendering 404", message);
     NotFoundTemplate {}.to_response()
 }
-

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,15 +1,17 @@
+use actix_web::{
+    http::{self, header::ContentType},
+    test, App,
+};
 #[cfg(test)]
 // TODO: Add steps or a bash script to run tests with a test DB
-
 use videas::routes::*;
-use actix_web::{http::{self, header::ContentType}, test, App};
 
 #[actix_web::test]
 async fn test_index_get() {
     let app = test::init_service(App::new().service(index)).await;
     let req = test::TestRequest::default()
-                .insert_header(ContentType::html())
-                .to_request();
+        .insert_header(ContentType::html())
+        .to_request();
     let res = test::call_service(&app, req).await;
 
     assert!(res.status().is_success());
@@ -19,12 +21,12 @@ async fn test_index_get() {
 async fn test_show_non_existent_post_get() {
     let app = test::init_service(App::new().service(show_post)).await;
     let req = test::TestRequest::get()
-                .uri("/this-post-doesnt-exist")
-                .insert_header(ContentType::html())
-                .to_request();
+        .uri("/this-post-doesnt-exist")
+        .insert_header(ContentType::html())
+        .to_request();
     let res = test::call_service(&app, req).await;
 
-    assert!(res.status().is_success());
+    assert!(res.status().is_client_error());
 }
 
 #[actix_web::test]
@@ -32,9 +34,9 @@ async fn test_show_post_get() {
     let app = test::init_service(App::new().service(show_post)).await;
     let req = test::TestRequest::get()
         // TODO: make sure you ran the seeds
-                .uri("/using-github-copilot-vim")
-                .insert_header(ContentType::html())
-                .to_request();
+        .uri("/using-github-copilot-vim")
+        .insert_header(ContentType::html())
+        .to_request();
     let res = test::call_service(&app, req).await;
 
     assert_eq!(res.status(), http::StatusCode::NOT_FOUND.as_u16());


### PR DESCRIPTION
### Use distroless image to run the application

- In order to get a distroless image (about 50 MB; compared to the previous ~2 GB) I'm using [cc-debian12](https://github.com/GoogleContainerTools/distroless) instead of using the rust image directly.
- Remove unnecessary steps from Dockerfile (diesel_cli)
-  Use specific Rust image version.